### PR TITLE
Fixed a bug online tracking wont work from version 1.3.1

### DIFF
--- a/minecraft.php
+++ b/minecraft.php
@@ -90,7 +90,7 @@ function parseLog(){
     if (preg_match("/([0-9-]+ [0-9:]+) \[INFO\] \<([a-zA-Z0-9-_]+)\> (.*)/i", $l, $m))
       $this->online($m[2], $m[1], 0, $m[3]);
     //check for users entering the server, set them online
-    else if (preg_match("/([0-9-]+ [0-9:]+) \[INFO\] ([a-zA-Z0-9-_]+) \[.*logged in with entity/i", $l, $m))
+    else if (preg_match("/([0-9-]+ [0-9:]+) \[INFO\] ([a-zA-Z0-9-_]+) ?\[.*logged in with entity/i", $l, $m))
       $this->online($m[2], $m[1], 1);
     //Check for users leaving, set them as offline
     else if (preg_match("/([0-9-]+ [0-9:]+) \[INFO\] ([a-zA-Z0-9-_]+) lost connection/i", $l, $m))


### PR DESCRIPTION
Fixed tracking who is online don’t work from minecraft server version 1.3.1

In the new version the log entry is changed, there is no space in the players name and ip block.

Solved the problem by putting a question mark in the regex between player and ip block.
